### PR TITLE
Fix text tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 /log.html
+/target
 build/

--- a/grammar.js
+++ b/grammar.js
@@ -1,8 +1,8 @@
-const WHITE_SPACE = choice(' ', '\t', '\v', '\f');
+const WHITE_SPACE = choice(" ", "\t", "\v", "\f");
 const NEWLINE = /\r?\n/;
 
 module.exports = grammar({
-  name: 'comment',
+  name: "comment",
 
   externals: $ => [
     $.name,
@@ -18,7 +18,7 @@ module.exports = grammar({
     source: $ => repeat(
       choice(
         $.tag,
-        alias($._text, 'text'),
+        alias($._text, "text"),
       ),
     ),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "nan": "^2.14.2"
       },
       "devDependencies": {
-        "tree-sitter-cli": "^0.19.3"
+        "tree-sitter-cli": "^0.19.4"
       }
     },
     "node_modules/nan": {
@@ -20,9 +20,9 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.3.tgz",
-      "integrity": "sha512-UlntGxLrlkQCKVrhm7guzfi+ovM4wDLVCCu3z5jmfDgFNoUoKa/23ddaQON5afD5jB9a02xv4N5MXJfCx+/mpw==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.4.tgz",
+      "integrity": "sha512-p2kxjuoQeauXBu5eE+j7c5BMCRXmc17EiAswnnWn3ieUlHXBkA0Z7vRnaCSElDR34MhZnSgqgzuuzQk0cDqCjw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -37,9 +37,9 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "tree-sitter-cli": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.3.tgz",
-      "integrity": "sha512-UlntGxLrlkQCKVrhm7guzfi+ovM4wDLVCCu3z5jmfDgFNoUoKa/23ddaQON5afD5jB9a02xv4N5MXJfCx+/mpw==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.19.4.tgz",
+      "integrity": "sha512-p2kxjuoQeauXBu5eE+j7c5BMCRXmc17EiAswnnWn3ieUlHXBkA0Z7vRnaCSElDR34MhZnSgqgzuuzQk0cDqCjw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "nan": "^2.14.2"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.3"
+    "tree-sitter-cli": "^0.19.4"
   }
 }

--- a/src/tree_sitter_comment/parser.c
+++ b/src/tree_sitter_comment/parser.c
@@ -3,7 +3,7 @@
 #include "tree_sitter_comment/chars.c"
 #include "tree_sitter_comment/tokens.h"
 
-/// Parse a the name of the tag.
+/// Parse the name of the tag.
 ///
 /// They can be of the form:
 /// - TODO:
@@ -43,12 +43,12 @@ bool parse_tagname(TSLexer* lexer, const bool* valid_symbols)
     }
     // Checking aperture.
     if (lexer->lookahead != '(') {
-      return parse_text(lexer, valid_symbols, true);
+      return parse_text(lexer, valid_symbols, false);
     }
     // Checking closure.
     while (lexer->lookahead != ')') {
       if (is_newline(lexer->lookahead)) {
-        return parse_text(lexer, valid_symbols, true);
+        return parse_text(lexer, valid_symbols, false);
       }
       lexer->advance(lexer, false);
     }
@@ -72,11 +72,15 @@ bool parse_tagname(TSLexer* lexer, const bool* valid_symbols)
 
 /// Parse normal text.
 ///
-/// Text nodes are september by white spaces or an start char like `(`
+/// Text nodes are separated by white spaces or an start char like `(`
 bool parse_text(TSLexer* lexer, const bool* valid_symbols, bool end)
 {
-  if (is_space(lexer->lookahead) || !valid_symbols[T_TEXT]) {
-    if (!end && valid_symbols[T_TEXT]) {
+  if (!valid_symbols[T_TEXT]) {
+    return false;
+  }
+
+  if (is_space(lexer->lookahead)) {
+    if (!end) {
       lexer->result_symbol = T_TEXT;
       return true;
     }


### PR DESCRIPTION
The following text was being parsed as one single "text" token instead of two

```
TODO something
```

tree-sitter doesn't allow testing anonymous nodes, so bear with me.