### PR TITLE
Use 'relative' paths for imports

### DIFF
--- a/src/tree_sitter_comment/chars.c
+++ b/src/tree_sitter_comment/chars.c
@@ -1,4 +1,4 @@
-#include "tree_sitter_comment/chars.h"
+#include "chars.h"
 
 bool is_upper(int32_t c)
 {

--- a/src/tree_sitter_comment/parser.c
+++ b/src/tree_sitter_comment/parser.c
@@ -1,7 +1,7 @@
-#include "tree_sitter_comment/parser.h"
+#include "parser.h"
 
-#include "tree_sitter_comment/chars.c"
-#include "tree_sitter_comment/tokens.h"
+#include "chars.c"
+#include "tokens.h"
 
 /// Parse the name of the tag.
 ///


### PR DESCRIPTION
So that these grammars can be built with non-npm methods.

This patch was sent via email from https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/45762.