### PR TITLE
Add support for parsing URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ I have chosen to follow popular conventions for the syntax.
 If you think there are other popular conventions this syntax doesn't cover,
 feel free to open a issue.
 
+URLs are also identified and can be highlighted via the (url) token.
+
+The current list of URL schemes is:
+
+* dns
+* file
+* ftp
+* http
+* https
+* ipp
+* mailto
+* sms
+* tel
+* telnet
+* ssh
+* urn
+* ws
+* wss
+
+
 ## Examples
 
 ```
@@ -37,7 +57,6 @@ NOTE_BUG: or by `_`.
 
 ## TODO
 
-- Detect links?
 - Detect tags that start with `#` (like when linking to a PR)?
 
 ## Why C?

--- a/grammar.js
+++ b/grammar.js
@@ -7,6 +7,7 @@ module.exports = grammar({
   externals: $ => [
     $.name,
     $._text,
+    $._url,
   ],
 
   extras: $ => [
@@ -19,6 +20,7 @@ module.exports = grammar({
       choice(
         $.tag,
         alias($._text, "text"),
+        alias($._url, $.url),
       ),
     ),
 
@@ -34,7 +36,7 @@ module.exports = grammar({
       ')',
     ),
 
-    __newline: $ => NEWLINE,
-    __whitespace: $ => token(WHITE_SPACE),
+    __newline: _ => NEWLINE,
+    __whitespace: _ => token(WHITE_SPACE),
   },
 });

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -18,6 +18,15 @@
             },
             "named": false,
             "value": "text"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_url"
+            },
+            "named": true,
+            "value": "url"
           }
         ]
       }
@@ -118,6 +127,10 @@
     {
       "type": "SYMBOL",
       "name": "_text"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_url"
     }
   ],
   "inline": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -10,6 +10,10 @@
         {
           "type": "tag",
           "named": true
+        },
+        {
+          "type": "url",
+          "named": true
         }
       ]
     }
@@ -52,6 +56,10 @@
   {
     "type": "text",
     "named": false
+  },
+  {
+    "type": "url",
+    "named": true
   },
   {
     "type": "user",

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,13 +5,13 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#define LANGUAGE_VERSION 13
+#define LANGUAGE_VERSION 14
 #define STATE_COUNT 12
 #define LARGE_STATE_COUNT 4
-#define SYMBOL_COUNT 13
+#define SYMBOL_COUNT 14
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 9
-#define EXTERNAL_TOKEN_COUNT 2
+#define TOKEN_COUNT 10
+#define EXTERNAL_TOKEN_COUNT 3
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 3
 #define PRODUCTION_ID_COUNT 1
@@ -25,10 +25,11 @@ enum {
   sym___whitespace = 6,
   sym_name = 7,
   sym__text = 8,
-  sym_source = 9,
-  sym_tag = 10,
-  sym__user = 11,
-  aux_sym_source_repeat1 = 12,
+  sym__url = 9,
+  sym_source = 10,
+  sym_tag = 11,
+  sym__user = 12,
+  aux_sym_source_repeat1 = 13,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -41,6 +42,7 @@ static const char * const ts_symbol_names[] = {
   [sym___whitespace] = "__whitespace",
   [sym_name] = "name",
   [sym__text] = "text",
+  [sym__url] = "url",
   [sym_source] = "source",
   [sym_tag] = "tag",
   [sym__user] = "_user",
@@ -57,6 +59,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym___whitespace] = sym___whitespace,
   [sym_name] = sym_name,
   [sym__text] = sym__text,
+  [sym__url] = sym__url,
   [sym_source] = sym_source,
   [sym_tag] = sym_tag,
   [sym__user] = sym__user,
@@ -100,6 +103,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [sym__url] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_source] = {
     .visible = true,
     .named = true,
@@ -124,6 +131,21 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
 
 static const uint16_t ts_non_terminal_alias_map[] = {
   0,
+};
+
+static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [3] = 3,
+  [4] = 4,
+  [5] = 5,
+  [6] = 6,
+  [7] = 7,
+  [8] = 8,
+  [9] = 9,
+  [10] = 10,
+  [11] = 11,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -197,9 +219,9 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [1] = {.lex_state = 0, .external_lex_state = 1},
   [2] = {.lex_state = 0, .external_lex_state = 1},
   [3] = {.lex_state = 0, .external_lex_state = 1},
-  [4] = {.lex_state = 0},
+  [4] = {.lex_state = 0, .external_lex_state = 1},
   [5] = {.lex_state = 0, .external_lex_state = 1},
-  [6] = {.lex_state = 0, .external_lex_state = 1},
+  [6] = {.lex_state = 0},
   [7] = {.lex_state = 0},
   [8] = {.lex_state = 2},
   [9] = {.lex_state = 0},
@@ -210,17 +232,20 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
 enum {
   ts_external_token_name = 0,
   ts_external_token__text = 1,
+  ts_external_token__url = 2,
 };
 
 static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
   [ts_external_token_name] = sym_name,
   [ts_external_token__text] = sym__text,
+  [ts_external_token__url] = sym__url,
 };
 
 static const bool ts_external_scanner_states[2][EXTERNAL_TOKEN_COUNT] = {
   [1] = {
     [ts_external_token_name] = true,
     [ts_external_token__text] = true,
+    [ts_external_token__url] = true,
   },
 };
 
@@ -234,6 +259,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym___whitespace] = ACTIONS(3),
     [sym_name] = ACTIONS(1),
     [sym__text] = ACTIONS(1),
+    [sym__url] = ACTIONS(1),
   },
   [1] = {
     [sym_source] = STATE(7),
@@ -244,6 +270,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym___whitespace] = ACTIONS(3),
     [sym_name] = ACTIONS(7),
     [sym__text] = ACTIONS(9),
+    [sym__url] = ACTIONS(9),
   },
   [2] = {
     [sym_tag] = STATE(3),
@@ -253,6 +280,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym___whitespace] = ACTIONS(3),
     [sym_name] = ACTIONS(7),
     [sym__text] = ACTIONS(13),
+    [sym__url] = ACTIONS(13),
   },
   [3] = {
     [sym_tag] = STATE(3),
@@ -262,61 +290,64 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym___whitespace] = ACTIONS(3),
     [sym_name] = ACTIONS(17),
     [sym__text] = ACTIONS(20),
+    [sym__url] = ACTIONS(20),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 4,
-    ACTIONS(23), 1,
+  [0] = 2,
+    ACTIONS(3), 2,
+      sym___newline,
+      sym___whitespace,
+    ACTIONS(23), 4,
+      sym_name,
+      sym__text,
+      sym__url,
+      ts_builtin_sym_end,
+  [11] = 2,
+    ACTIONS(3), 2,
+      sym___newline,
+      sym___whitespace,
+    ACTIONS(25), 4,
+      sym_name,
+      sym__text,
+      sym__url,
+      ts_builtin_sym_end,
+  [22] = 4,
+    ACTIONS(27), 1,
       anon_sym_COLON,
-    ACTIONS(25), 1,
+    ACTIONS(29), 1,
       anon_sym_LPAREN,
     STATE(9), 1,
       sym__user,
     ACTIONS(3), 2,
       sym___newline,
       sym___whitespace,
-  [14] = 2,
-    ACTIONS(3), 2,
-      sym___newline,
-      sym___whitespace,
-    ACTIONS(27), 3,
-      sym_name,
-      sym__text,
-      ts_builtin_sym_end,
-  [24] = 2,
-    ACTIONS(3), 2,
-      sym___newline,
-      sym___whitespace,
-    ACTIONS(29), 3,
-      sym_name,
-      sym__text,
-      ts_builtin_sym_end,
-  [34] = 2,
+  [36] = 2,
     ACTIONS(31), 1,
       ts_builtin_sym_end,
     ACTIONS(3), 2,
       sym___newline,
       sym___whitespace,
-  [42] = 2,
+  [44] = 2,
     ACTIONS(33), 1,
       aux_sym__user_token1,
     ACTIONS(35), 2,
       sym___newline,
       sym___whitespace,
-  [50] = 2,
+  [52] = 2,
     ACTIONS(37), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
       sym___newline,
       sym___whitespace,
-  [58] = 2,
+  [60] = 2,
     ACTIONS(39), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym___newline,
       sym___whitespace,
-  [66] = 2,
+  [68] = 2,
     ACTIONS(41), 1,
       anon_sym_COLON,
     ACTIONS(3), 2,
@@ -326,13 +357,13 @@ static const uint16_t ts_small_parse_table[] = {
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(4)] = 0,
-  [SMALL_STATE(5)] = 14,
-  [SMALL_STATE(6)] = 24,
-  [SMALL_STATE(7)] = 34,
-  [SMALL_STATE(8)] = 42,
-  [SMALL_STATE(9)] = 50,
-  [SMALL_STATE(10)] = 58,
-  [SMALL_STATE(11)] = 66,
+  [SMALL_STATE(5)] = 11,
+  [SMALL_STATE(6)] = 22,
+  [SMALL_STATE(7)] = 36,
+  [SMALL_STATE(8)] = 44,
+  [SMALL_STATE(9)] = 52,
+  [SMALL_STATE(10)] = 60,
+  [SMALL_STATE(11)] = 68,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -340,21 +371,21 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
   [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
   [11] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source, 1),
   [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
   [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2),
-  [17] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(4),
+  [17] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(6),
   [20] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_repeat1, 2), SHIFT_REPEAT(3),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
-  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
   [31] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
   [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
   [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
   [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
   [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__user, 3),
 };
@@ -404,6 +435,7 @@ extern const TSLanguage *tree_sitter_comment(void) {
       tree_sitter_comment_external_scanner_serialize,
       tree_sitter_comment_external_scanner_deserialize,
     },
+    .primary_state_ids = ts_primary_state_ids,
   };
   return &language;
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,15 +1,16 @@
 #include <tree_sitter/parser.h>
 
-#include "tree_sitter_comment/parser.c"
+#include "tree_sitter_comment/scanner.c"
 #include "tree_sitter_comment/tokens.h"
 
 void* tree_sitter_comment_external_scanner_create()
 {
-  return NULL;
+  return new_comment_scanner();
 }
 
 void tree_sitter_comment_external_scanner_destroy(void* payload)
 {
+  destroy_comment_scanner(payload);
 }
 
 unsigned tree_sitter_comment_external_scanner_serialize(
@@ -31,5 +32,10 @@ bool tree_sitter_comment_external_scanner_scan(
     TSLexer* lexer,
     const bool* valid_symbols)
 {
-  return parse(lexer, valid_symbols);
+  CommentScanner* scanner = (CommentScanner*)payload;
+  scanner->lexer = lexer;
+  scanner->valid_symbols = valid_symbols;
+  scanner->lookahead = lexer->lookahead;
+  scanner->previous = lexer->lookahead;
+  return scanner->scan(scanner);
 }

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*

--- a/src/tree_sitter_comment/chars.c
+++ b/src/tree_sitter_comment/chars.c
@@ -1,17 +1,35 @@
+#include <string.h>
 #include "chars.h"
-
-bool is_upper(int32_t c)
-{
-  const int32_t upper = 65;
-  const int32_t lower = 90;
-  return c >= upper && c <= lower;
-}
 
 bool is_digit(int32_t c)
 {
   const int32_t upper = 48;
   const int32_t lower = 57;
   return c >= upper && c <= lower;
+}
+
+bool is_abc_upper(int32_t c)
+{
+  const int32_t upper = 65;
+  const int32_t lower = 90;
+  return c >= upper && c <= lower;
+}
+
+bool is_abc_lower(int32_t c)
+{
+  const int32_t upper = 97;
+  const int32_t lower = 122;
+  return c >= upper && c <= lower;
+}
+
+bool is_abc(int32_t c)
+{
+  return is_abc_lower(c) || is_abc_upper(c);
+}
+
+bool is_alphanumeric(int32_t c)
+{
+  return is_abc(c) || is_digit(c);
 }
 
 bool is_newline(int32_t c)
@@ -114,6 +132,55 @@ bool is_end_char(int32_t c)
   const int length = sizeof(valid_chars) / sizeof(int32_t);
   for (int i = 0; i < length; i++) {
     if (c == valid_chars[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool is_known_schema(char* string, unsigned string_len)
+{
+  char* valid_schemas[] = {
+    "dns",
+    "file",
+    "ftp",
+    "http",
+    "https",
+    "ipp",
+    "mailto",
+    "sms",
+    "tel",
+    "telnet",
+    "ssh",
+    "urn",
+    "ws",
+    "wss",
+  };
+
+  const int length = sizeof(valid_schemas) / sizeof(char*);
+  for (int i = 0; i < length; i++) {
+    if (string_len != strlen(valid_schemas[i])) {
+      continue;
+    }
+    int result = memcmp(string, valid_schemas[i], string_len);
+    if (result == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool is_invalid_uri_char(int32_t c)
+{
+  const int32_t invalid_chars[] = {
+    '^',
+    '}',
+    '{',
+    '\\',
+  };
+  const int length = sizeof(invalid_chars) / sizeof(int32_t);
+  for (int i = 0; i < length; i++) {
+    if (c == invalid_chars[i]) {
       return true;
     }
   }

--- a/src/tree_sitter_comment/chars.h
+++ b/src/tree_sitter_comment/chars.h
@@ -16,8 +16,14 @@
 bool is_internal_char(int32_t c);
 bool is_newline(int32_t c);
 bool is_space(int32_t c);
-bool is_upper(int32_t c);
+bool is_abc_upper(int32_t c);
 bool is_digit(int32_t c);
 bool is_start_char(int32_t c);
+bool is_end_char(int32_t c);
+bool is_abc_lower(int32_t c);
+bool is_abc(int32_t c);
+bool is_alphanumeric(int32_t c);
+bool is_known_schema(char* string, unsigned strlen);
+bool is_invalid_uri_char(int32_t c);
 
 #endif /* ifndef TREE_SITTER_COMMENT_CHARS_H */

--- a/src/tree_sitter_comment/parser.c
+++ b/src/tree_sitter_comment/parser.c
@@ -4,11 +4,6 @@
 #include "tree_sitter_comment/chars.h"
 #include "tree_sitter_comment/tokens.h"
 
-/* #include "parser.h" */
-/**/
-/* #include "chars.c" */
-/* #include "tokens.h" */
-
 /// Parse the name of the tag.
 ///
 /// They can be of the form:

--- a/src/tree_sitter_comment/parser.c
+++ b/src/tree_sitter_comment/parser.c
@@ -1,7 +1,13 @@
-#include "parser.h"
+#include <stdio.h>
+#include "tree_sitter_comment/parser.h"
 
-#include "chars.c"
-#include "tokens.h"
+#include "tree_sitter_comment/chars.h"
+#include "tree_sitter_comment/tokens.h"
+
+/* #include "parser.h" */
+/**/
+/* #include "chars.c" */
+/* #include "tokens.h" */
 
 /// Parse the name of the tag.
 ///
@@ -11,114 +17,203 @@
 /// - TODO(stsewd):
 /// - TODO(stsewd): text
 /// - TODO (stsewd): text
-bool parse_tagname(TSLexer* lexer, const bool* valid_symbols)
+bool parse_tagname(CommentScanner* scanner)
 {
-  if (!is_upper(lexer->lookahead) || !valid_symbols[T_TAGNAME]) {
+  TSLexer* lexer = scanner->lexer;
+  const bool* valid_symbols = scanner->valid_symbols;
+
+  if (!is_abc_upper(scanner->lookahead) || !valid_symbols[T_TAGNAME]) {
     return false;
   }
 
-  int32_t previous = lexer->lookahead;
-  lexer->advance(lexer, false);
+  int32_t previous = scanner->lookahead;
+  scanner->advance(scanner);
 
-  while (is_upper(lexer->lookahead)
-      || is_digit(lexer->lookahead)
-      || is_internal_char(lexer->lookahead)) {
-    previous = lexer->lookahead;
-    lexer->advance(lexer, false);
+  while (is_abc_upper(scanner->lookahead)
+      || is_digit(scanner->lookahead)
+      || is_internal_char(scanner->lookahead)) {
+    previous = scanner->lookahead;
+    scanner->advance(scanner);
   }
   lexer->mark_end(lexer);
 
   // It can't end with an internal char.
   if (is_internal_char(previous)) {
-    return parse_text(lexer, valid_symbols, false);
+    return parse_text(scanner, false);
   }
 
   // For the user component this is `\s*(`.
   // We don't parse that part, we just need to be sure it ends with `:\s`.
-  if ((is_space(lexer->lookahead) && !is_newline(lexer->lookahead))
-      || lexer->lookahead == '(') {
+  if ((is_space(scanner->lookahead) && !is_newline(scanner->lookahead))
+      || scanner->lookahead == '(') {
     // Skip white spaces.
-    while (is_space(lexer->lookahead) && !is_newline(lexer->lookahead)) {
-      lexer->advance(lexer, false);
+    while (is_space(scanner->lookahead) && !is_newline(scanner->lookahead)) {
+      scanner->advance(scanner);
     }
     // Checking aperture.
-    if (lexer->lookahead != '(') {
-      return parse_text(lexer, valid_symbols, false);
+    if (scanner->lookahead != '(') {
+      return parse_text(scanner, false);
     }
-    lexer->advance(lexer, false);
+    scanner->advance(scanner);
 
     // Checking closure.
     int user_length = 0;
-    while (lexer->lookahead != ')') {
-      if (is_newline(lexer->lookahead)) {
-        return parse_text(lexer, valid_symbols, false);
+    while (scanner->lookahead != ')') {
+      if (is_newline(scanner->lookahead)) {
+        return parse_text(scanner, false);
       }
-      lexer->advance(lexer, false);
+      scanner->advance(scanner);
       user_length++;
     }
     if (user_length <= 0) {
-      return parse_text(lexer, valid_symbols, false);
+      return parse_text(scanner, false);
     }
-    lexer->advance(lexer, false);
+    scanner->advance(scanner);
   }
 
   // It should end with `:`...
-  if (lexer->lookahead != ':') {
-    return parse_text(lexer, valid_symbols, false);
+  if (scanner->lookahead != ':') {
+    return parse_text(scanner, false);
   }
 
   // ... and be followed by one space.
-  lexer->advance(lexer, false);
-  if (!is_space(lexer->lookahead)) {
-    return parse_text(lexer, valid_symbols, false);
+  scanner->advance(scanner);
+  if (!is_space(scanner->lookahead)) {
+    return parse_text(scanner, false);
   }
 
   lexer->result_symbol = T_TAGNAME;
   return true;
 }
 
+bool parse_url(CommentScanner* scanner)
+{
+  const bool* valid_symbols = scanner->valid_symbols;
+
+  if (!is_abc(scanner->lookahead) || !valid_symbols[T_URL]) {
+    return false;
+  }
+  scanner->advance(scanner);
+  return parse_inner_url(scanner);
+}
+
+// Borrowed (mostly) from tree-sitter-rst.
+//
+// Extract URLs for those that have schemes as defined in chars.c/is_known_schema()
+bool parse_inner_url(CommentScanner* scanner)
+{
+  TSLexer* lexer = scanner->lexer;
+
+  const unsigned MAX_SCHEMA_LEN = 20;
+  char* schema = malloc(sizeof(char) * MAX_SCHEMA_LEN);
+  unsigned consumed_chars = 0;
+
+  schema[consumed_chars++] = (char)scanner->previous;
+
+  while (consumed_chars < MAX_SCHEMA_LEN) {
+    if (!is_alphanumeric(scanner->lookahead)) {
+      break;
+    }
+    schema[consumed_chars++] = (char)scanner->lookahead;
+    scanner->advance(scanner);
+  }
+
+  bool is_word = false;
+
+  if (is_start_char(scanner->lookahead)) {
+    lexer->mark_end(lexer);
+  }
+
+  bool is_valid = false;
+
+  if (scanner->lookahead == ':') {
+    is_valid = is_known_schema(schema, consumed_chars);
+  } else if (scanner->lookahead == '@') {
+    is_valid = true;
+  }
+
+  // Clean up
+  free(schema);
+  schema = NULL;
+
+  if (!is_valid) {
+    return parse_text(scanner, !is_word);
+  }
+
+  scanner->advance(scanner);
+
+  if (scanner->lookahead == '/') {
+    scanner->advance(scanner);
+  } else if (!is_alphanumeric(scanner->lookahead)) {
+    return parse_text(scanner, !is_word);
+  }
+
+  consumed_chars = 0;
+  bool is_escaped = false;
+  while (true) {
+    lexer->mark_end(lexer);
+    if (scanner->lookahead == '\\') {
+      scanner->advance(scanner);
+      is_escaped = true;
+    } else {
+      is_escaped = false;
+    }
+    if (is_invalid_uri_char(scanner->lookahead)) {
+      break;
+    }
+    if (is_space(scanner->lookahead)
+        || (is_end_char(scanner->lookahead) && !is_escaped && scanner->lookahead != '/')) {
+      if (is_end_char(scanner->lookahead)) {
+        lexer->mark_end(lexer);
+        scanner->advance(scanner);
+        if (!is_alphanumeric(scanner->lookahead)) {
+          lexer->result_symbol = T_URL;
+          return true;
+        }
+      } else {
+        break;
+      }
+    }
+    scanner->advance(scanner);
+    consumed_chars++;
+  }
+
+  if (consumed_chars > 0) {
+    lexer->result_symbol = T_URL;
+    return true;
+  }
+
+  return parse_text(scanner, !is_word);
+}
+
 /// Parse normal text.
 ///
 /// Text nodes are separated by white spaces or an start char like `(`
-bool parse_text(TSLexer* lexer, const bool* valid_symbols, bool end)
+bool parse_text(CommentScanner* scanner, bool end)
 {
+  TSLexer* lexer = scanner->lexer;
+  const bool* valid_symbols = scanner->valid_symbols;
+
   if (!valid_symbols[T_TEXT]) {
     return false;
   }
 
-  if (is_space(lexer->lookahead)) {
-    if (!end) {
-      lexer->result_symbol = T_TEXT;
-      return true;
-    }
-    return false;
-  }
+  if (is_start_char(scanner->lookahead) || is_end_char(scanner->lookahead)) {
+    scanner->advance(scanner);
 
-  if (is_start_char(lexer->lookahead) || is_end_char(lexer->lookahead)) {
-    lexer->advance(lexer, false);
   } else {
-    while (!is_space(lexer->lookahead)) {
-      if (is_start_char(lexer->lookahead) || is_end_char(lexer->lookahead)) {
+    while (!is_space(scanner->lookahead)) {
+      if (is_start_char(scanner->lookahead) || is_end_char(scanner->lookahead)) {
         break;
       }
-      lexer->advance(lexer, false);
+      scanner->advance(scanner);
     }
   }
 
   if (end) {
     lexer->mark_end(lexer);
   }
+
   lexer->result_symbol = T_TEXT;
   return true;
-}
-
-bool parse(TSLexer* lexer, const bool* valid_symbols)
-{
-  if (is_upper(lexer->lookahead) && valid_symbols[T_TAGNAME]) {
-    return parse_tagname(lexer, valid_symbols);
-  }
-  if (!is_space(lexer->lookahead) && valid_symbols[T_TEXT]) {
-    return parse_text(lexer, valid_symbols, true);
-  }
-  return false;
 }

--- a/src/tree_sitter_comment/parser.c
+++ b/src/tree_sitter_comment/parser.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "tree_sitter_comment/parser.h"
 
 #include "tree_sitter_comment/chars.h"

--- a/src/tree_sitter_comment/parser.h
+++ b/src/tree_sitter_comment/parser.h
@@ -3,8 +3,12 @@
 
 #include <tree_sitter/parser.h>
 
-bool parse_tagname(TSLexer* lexer, const bool* valid_symbols);
-bool parse_text(TSLexer* lexer, const bool* valid_symbols, bool end);
-bool parse(TSLexer* lexer, const bool* valid_symbols);
+#include "tree_sitter_comment/scanner.h"
+#include "tree_sitter_comment/tokens.h"
+
+bool parse_tagname(CommentScanner* scanner);
+bool parse_url(CommentScanner* scanner);
+bool parse_inner_url(CommentScanner* scanner);
+bool parse_text(CommentScanner* scanner, bool end);
 
 #endif /* ifndef TREE_SITTER_COMMENT_PARSER_H */

--- a/src/tree_sitter_comment/scanner.c
+++ b/src/tree_sitter_comment/scanner.c
@@ -1,0 +1,55 @@
+#include "tree_sitter_comment/scanner.h"
+
+#include <string.h>
+
+#include "tree_sitter_comment/chars.c"
+#include "tree_sitter_comment/parser.c"
+#include "tree_sitter_comment/tokens.h"
+
+// Build a new `CommentScanner` object.
+//
+// `destroy_comment_scanner` should be called to safely destroy this object.
+CommentScanner* new_comment_scanner()
+{
+  CommentScanner* scanner = malloc(sizeof(CommentScanner));
+
+  scanner->advance = comment_scanner_advance;
+  scanner->scan = comment_scanner_scan;
+
+  return scanner;
+}
+
+void destroy_comment_scanner(CommentScanner* scanner)
+{
+  free(scanner);
+}
+
+// Keep track of the previous token so we can match valid URL schemes.
+void comment_scanner_advance(CommentScanner* scanner)
+{
+  TSLexer* lexer = scanner->lexer;
+  scanner->previous = scanner->lookahead;
+  lexer->advance(lexer, false);
+  scanner->lookahead = lexer->lookahead;
+}
+
+bool comment_scanner_scan(CommentScanner* scanner)
+{
+  TSLexer* lexer = scanner->lexer;
+  const bool* valid_symbols = scanner->valid_symbols;
+  int32_t current = lexer->lookahead;
+
+  if (is_abc_upper(lexer->lookahead) && valid_symbols[T_TAGNAME]) {
+    return parse_tagname(scanner);
+  }
+
+  if (is_abc(lexer->lookahead) && valid_symbols[T_URL]) {
+    return parse_url(scanner);
+  }
+
+  if (!is_space(lexer->lookahead) && valid_symbols[T_TEXT]) {
+    return parse_text(scanner, true);
+  }
+
+  return false;
+}

--- a/src/tree_sitter_comment/scanner.h
+++ b/src/tree_sitter_comment/scanner.h
@@ -1,0 +1,26 @@
+#ifndef TREE_SITTER_COMMENT_SCANNER_H
+#define TREE_SITTER_COMMENT_SCANNER_H
+
+#include <tree_sitter/parser.h>
+
+typedef struct CommentScanner CommentScanner;
+
+/// Wrapper struct around ``TSLexer`` to track the previous char for URI scheme identification.
+struct CommentScanner {
+  TSLexer* lexer;
+  const bool* valid_symbols;
+
+  int32_t lookahead;
+  int32_t previous;
+
+  void (*advance)(CommentScanner* scanner);
+  bool (*scan)(CommentScanner* scanner);
+};
+
+CommentScanner* new_comment_scanner();
+void destroy_comment_scanner(CommentScanner* scanner);
+
+void comment_scanner_advance(CommentScanner* scanner);
+bool comment_scanner_scan(CommentScanner* scanner);
+
+#endif

--- a/src/tree_sitter_comment/tokens.h
+++ b/src/tree_sitter_comment/tokens.h
@@ -4,6 +4,7 @@
 enum TokenType {
   T_TAGNAME,
   T_TEXT,
+  T_URL,
 };
 
 #endif /* ifndef TREE_SITTER_COMMENT_TOKENS_H */

--- a/test/corpus/source.txt
+++ b/test/corpus/source.txt
@@ -18,6 +18,12 @@ NOTE:
 
 DEBUG: thís shoúld wórk with $weird$ symbols
 
+https://github.com/
+
+foo "<https://github.com/>" bar
+
+TODO: https://user:pass@github.com/org/repo/?foo=baz
+
 ---
 
 (source
@@ -27,7 +33,11 @@ DEBUG: thís shoúld wórk with $weird$ symbols
   (tag (name))
   (tag (name))
   (tag (name))
-  (tag (name)))
+  (tag (name))
+  (url)
+  (url)
+  (tag (name))
+  (url))
 
 ==============
 Decorated tags


### PR DESCRIPTION
This fixes #15, using the URL parsing code from your `tree-sitter-rst` repository: https://github.com/stsewd/tree-sitter-rst/blob/master/src/tree_sitter_rst/parser.c#L1312

In Neovim, I can now add:

```scheme
; extends

(url) @text.uri
```

In a `after/queries/comment/highlights.scm` file. This should be integrated into `nvim-treesitter` itself after merging.