### PR TITLE
docs: add zed-todo-tree to README list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ it requires some manual parsing in C.
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - [helix](https://github.com/helix-editor/helix)
 - [zed-comment](https://github.com/thedadams/zed-comment)
+- [zed-todo-tree](https://github.com/alexandretrotel/zed-todo-tree)
 - Yours?
 
 ## Other grammars


### PR DESCRIPTION
Added **[zed-todo-tree](https://github.com/alexandretrotel/zed-todo-tree)** to the list of projects using **tree-sitter-comment**.

**zed-todo-tree** is a Zed extension that highlights TODO comments and other annotated tags in code, using **tree-sitter-comment** for parsing.

This extension is part of the broader **[todo-tree](https://github.com/alexandretrotel/todo-tree)** project, which also includes a CLI tool, a GitHub Action, and additional integrations.